### PR TITLE
Regularize the example executables

### DIFF
--- a/examples/hoedown.c
+++ b/examples/hoedown.c
@@ -9,12 +9,10 @@
 #define READ_UNIT 1024
 #define OUTPUT_UNIT 64
 
-/* main • main function, interfacing STDIO with the parser */
 int
 main(int argc, char **argv)
 {
 	struct hoedown_buffer *ib, *ob;
-	int ret;
 	FILE *in = stdin;
 
 	struct hoedown_callbacks callbacks;
@@ -25,7 +23,7 @@ main(int argc, char **argv)
 	if (argc > 1) {
 		in = fopen(argv[1], "r");
 		if (!in) {
-			fprintf(stderr,"Unable to open input file \"%s\": %s\n", argv[1], strerror(errno));
+			fprintf(stderr, "Unable to open input file \"%s\": %s\n", argv[1], strerror(errno));
 			return 1;
 		}
 	}
@@ -50,11 +48,11 @@ main(int argc, char **argv)
 	hoedown_markdown_free(markdown);
 
 	/* writing the result to stdout */
-	ret = fwrite(ob->data, 1, ob->size, stdout);
+	(void)fwrite(ob->data, 1, ob->size, stdout);
 
 	/* cleanup */
 	hoedown_buffer_release(ib);
 	hoedown_buffer_release(ob);
 
-	return (ret < 0) ? -1 : 0;
+	return ferror(stdout);
 }

--- a/examples/smartypants.c
+++ b/examples/smartypants.c
@@ -1,7 +1,6 @@
 #include "html.h"
 
 #include <errno.h>
-#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -13,14 +12,13 @@ int
 main(int argc, char **argv)
 {
 	struct hoedown_buffer *ib, *ob;
-	size_t ret;
 	FILE *in = stdin;
 
 	/* opening the file if given from the command line */
 	if (argc > 1) {
 		in = fopen(argv[1], "r");
 		if (!in) {
-			fprintf(stderr, "Unable to open input file \"%s\": %s\n", argv[0], strerror(errno));
+			fprintf(stderr, "Unable to open input file \"%s\": %s\n", argv[1], strerror(errno));
 			return 1;
 		}
 	}
@@ -47,5 +45,5 @@ main(int argc, char **argv)
 	hoedown_buffer_release(ib);
 	hoedown_buffer_release(ob);
 
-	return 0;
+	return ferror(stdout);
 }


### PR DESCRIPTION
The loop that reads from stdin (or files) on the
example executables is complex and doesn't
test for `feof`.

Also the return value was always zero for
`smartypants`, and based on the output of
`fwrite` on `hoedown` (which isn't correct).
This has been corrected.
