### PR TITLE
Use size_t to avoid warning

### DIFF
--- a/src/html_smartypants.c
+++ b/src/html_smartypants.c
@@ -211,7 +211,7 @@ smartypants_cb__dash(hoedown_buffer *ob, struct smartypants_data *smrt, uint8_t 
 static size_t
 smartypants_cb__amp(hoedown_buffer *ob, struct smartypants_data *smrt, uint8_t previous_char, const uint8_t *text, size_t size)
 {
-	int len;
+	size_t len;
 	if (size >= 6 && memcmp(text, "&quot;", 6) == 0) {
 		if (smartypants_quotes(ob, previous_char, size >= 7 ? text[6] : 0, 'd', &smrt->in_dquote))
 			return 5;


### PR DESCRIPTION
When -Wshorten-64-to-32 is used (with LLVM) the following warning is triggered

```
hoedown/src/html_smartypants.c:220:8: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int' [-Wshorten-64-to-32]
        len = squote_len(text, size);
            ~ ^~~~~~~~~~~~~~~~~~~~~~
```

This tremendous effort of a pull request fixes this.
