### PR TITLE
Fix object compilation target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS = -c -g -O3 -Wall -Wextra -Wno-unused-parameter -Isrc
+CFLAGS = -g -O3 -Wall -Wextra -Wno-unused-parameter -Isrc
 
 ifneq ($(OS),Windows_NT)
 	CFLAGS += -fPIC
@@ -57,5 +57,5 @@ clean:
 
 # Generic object compilations
 
-%.o: src/%.c examples/%.c
-	$(CC) $(CFLAGS) -o $@ $<
+%.o: %.c
+	$(CC) $(CFLAGS) -c -o $@ $<


### PR DESCRIPTION
The target on line 60 of the Makefile isn't currently being used. Running `make` falls back to the built-in rules and running `make -r` errors out.

This patch fixes the dep paths and also makes it impossible to omit `-c` from `CFLAGS`, as the built-ins [do](http://www.gnu.org/software/make/manual/html_node/Catalogue-of-Rules.html).
