### PR TITLE
Properly check errors in executables

### DIFF
--- a/examples/hoedown.c
+++ b/examples/hoedown.c
@@ -36,7 +36,7 @@ main(int argc, char **argv)
 
 	while (!feof(in)) {
 		if (ferror(in)) {
-			fprintf(stderr, "I/O error found while reading input file.\n");
+			fprintf(stderr, "I/O errors found while reading input.\n");
 			return 1;
 		}
 		if (hoedown_buffer_grow(ib, ib->size + READ_UNIT) != HOEDOWN_BUF_OK) {
@@ -71,5 +71,10 @@ main(int argc, char **argv)
 	hoedown_buffer_free(ib);
 	hoedown_buffer_free(ob);
 
-	return ferror(stdout);
+	if (ferror(stdout)) {
+		fprintf(stderr, "I/O errors found while writing output.\n");
+		return 1;
+	}
+
+	return 0;
 }

--- a/examples/smartypants.c
+++ b/examples/smartypants.c
@@ -32,7 +32,7 @@ main(int argc, char **argv)
 
 	while (!feof(in)) {
 		if (ferror(in)) {
-			fprintf(stderr, "I/O error found while reading input file.\n");
+			fprintf(stderr, "I/O error found while reading input.\n");
 			return 1;
 		}
 		if (hoedown_buffer_grow(ib, ib->size + READ_UNIT) != HOEDOWN_BUF_OK) {
@@ -61,5 +61,10 @@ main(int argc, char **argv)
 	hoedown_buffer_free(ib);
 	hoedown_buffer_free(ob);
 
-	return ferror(stdout);
+	if (ferror(stdout)) {
+		fprintf(stderr, "I/O errors found while writing output.\n");
+		return 1;
+	}
+
+	return 0;
 }


### PR DESCRIPTION
Instead of silently stopping reading when errors appear, report to stderr and fail.
Also, check for `buffer_new` and `buffer_grow` errors.

Haven't tried, but after this Hoedown should parse large files without problems, at least in the executables. Can anyone confirm?
