### PR TITLE
examples/hoedown: enable extensions with -e flag

### DIFF
--- a/examples/hoedown.c
+++ b/examples/hoedown.c
@@ -17,13 +17,57 @@ main(int argc, char **argv)
 
 	hoedown_renderer *renderer;
 	hoedown_markdown *markdown;
+	unsigned int extensions = 0;
 
-	/* opening the file if given from the command line */
-	if (argc > 1) {
-		in = fopen(argv[1], "r");
-		if (!in) {
-			fprintf(stderr, "Unable to open input file \"%s\": %s\n", argv[1], strerror(errno));
-			return 1;
+	int i;
+	char *earg;
+
+	for (i = 1; i < argc; i++) {
+		if (strcmp(argv[i], "-e") == 0) {
+			if (i+1 >= argc) {
+				fprintf(stderr, "Expected a list of extensions to activate\n");
+				return 1;
+			}
+
+			while ((earg = strsep(&argv[i+1], ",")) != NULL) {
+				if (strcmp(earg, "no-intra-emphasis") == 0) {
+					extensions |= HOEDOWN_EXT_NO_INTRA_EMPHASIS;
+				} else if (strcmp(earg, "tables") == 0) {
+					extensions |= HOEDOWN_EXT_TABLES;
+				} else if (strcmp(earg, "fenced-code") == 0) {
+					extensions |= HOEDOWN_EXT_FENCED_CODE;
+				} else if (strcmp(earg, "autolink") == 0) {
+					extensions |= HOEDOWN_EXT_AUTOLINK;
+				} else if (strcmp(earg, "strikethrough") == 0) {
+					extensions |= HOEDOWN_EXT_STRIKETHROUGH;
+				} else if (strcmp(earg, "underline") == 0) {
+					extensions |= HOEDOWN_EXT_UNDERLINE;
+				} else if (strcmp(earg, "space-headers") == 0) {
+					extensions |= HOEDOWN_EXT_SPACE_HEADERS;
+				} else if (strcmp(earg, "superscript") == 0) {
+					extensions |= HOEDOWN_EXT_SUPERSCRIPT;
+				} else if (strcmp(earg, "lax-spacing") == 0) {
+					extensions |= HOEDOWN_EXT_LAX_SPACING;
+				} else if (strcmp(earg, "disable-indented-code") == 0) {
+					extensions |= HOEDOWN_EXT_DISABLE_INDENTED_CODE;
+				} else if (strcmp(earg, "highlight") == 0) {
+					extensions |= HOEDOWN_EXT_HIGHLIGHT;
+				} else if (strcmp(earg, "footnotes") == 0) {
+					extensions |= HOEDOWN_EXT_FOOTNOTES;
+				} else if (strcmp(earg, "quote") == 0) {
+					extensions |= HOEDOWN_EXT_QUOTE;
+				}
+			}
+			i++;
+
+		} else {
+			/* opening the file if given from the command line */
+			in = fopen(argv[i], "r");
+			if (!in) {
+				fprintf(stderr, "Unable to open input file \"%s\": %s\n",
+				argv[i], strerror(errno));
+				return 1;
+			}
 		}
 	}
 
@@ -41,7 +85,7 @@ main(int argc, char **argv)
 	ob = hoedown_buffer_new(OUTPUT_UNIT);
 
 	renderer = hoedown_html_renderer_new(0, 0);
-	markdown = hoedown_markdown_new(0, 16, renderer);
+	markdown = hoedown_markdown_new(extensions, 16, renderer);
 
 	hoedown_markdown_render(ob, ib->data, ib->size, markdown);
 


### PR DESCRIPTION
The examples/hoedown binary is useful for using as a command line markdown parser, but I needed to be able to enable some extensions.

Maybe the examples/ should be moved to bin/ to indicate that they are quite capable?
