### PR TITLE
Update README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ Features
 	`Hoedown` is a zero-dependency library composed of some `.c` files and their
 	headers. No dependencies, no bullshit. Only standard C99 that builds everywhere.
 
+*	**Additional features**
+
+	`Hoedown` comes with a fully functional implementation of SmartyPants,
+	a separate autolinker, escaping utilities, buffers and stacks.
+
 Bindings
 --------
 


### PR DESCRIPTION
Hoedown is now a serious library. It's no longer a pair of `.c` files and their headers.
README should be updated to reflect this.

The Install section is now outdated and doesn't give importance to the `Makefile`.
I have rewritten it to favour it as the main building method.

Of course, you can still drop the files onto your project; the point still stands.
