### PR TITLE
Add a note about CocoaPods to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,4 +96,6 @@ Just typing `make` will build `Hoedown` into a dynamic library and create the `h
 and `smartypants` executables, which are command-line tools to render Markdown to HTML
 and perform SmartyPants, respectively.
 
+If you are using [CocoaPods](http://cocoapods.org), just add the line `pod 'hoedown'` to your Podfile and call `pod install`.
+
 Or, if you prefer, you can just throw the files at `src` into your project.


### PR DESCRIPTION
Add a small note about installing hoedown via CocoaPods.

I created the hoedown spec, because I use CocoaPods extensively in my projects and in the past weeks I really fell in love with hoedown, so I had to add it to CocoaPods/Specs ;)

See: https://github.com/CocoaPods/Specs/blob/master/hoedown/2.0.0/hoedown.podspec
