### PR TITLE
Fix implicit conversion loss compiler warning in parse_codefence

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -1356,7 +1356,7 @@ is_codefence(uint8_t *data, size_t size, size_t *width, uint8_t *chr)
 }
 
 /* expects single line, checks if it's a codefence and extracts language */
-static int
+static size_t
 parse_codefence(uint8_t *data, size_t size, hoedown_buffer *lang, size_t *width, uint8_t *chr)
 {
 	size_t i, w, lang_start;


### PR DESCRIPTION
Changed the return type of `parse_codefence` in `document.c` from `int` to `size_t`. After that, my compiler (clang 503 from LLVM 3.4) does not complain any more about implicit conversion loss.

Tests are still passing.
