### PR TITLE
Improve hoedowns gitignore file for Mac users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ hoedown.exp
 hoedown.lib
 smartypants
 libhoedown.so*
+.DS_Store


### PR DESCRIPTION
On Mac OS X there is an annoying hidden file called `.DS_Store`, which is created in nearly every directory. It would be nice for Mac users if that line was in the gitignore file to not accidentally commit it. Thanks.
