### PR TITLE
Add hooks and fields to support custom rendering

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -127,6 +127,9 @@ struct hoedown_renderer {
 	/* header and footer */
 	void (*doc_header)(hoedown_buffer *ob, void *opaque);
 	void (*doc_footer)(hoedown_buffer *ob, void *opaque);
+
+    /* custom construct */
+    void (*custom)(hoedown_buffer *ob, void *data, void *opaque);
 };
 
 typedef struct hoedown_renderer hoedown_renderer;
@@ -144,6 +147,21 @@ hoedown_document_new(
 	const hoedown_renderer *renderer,
 	unsigned int extensions,
 	size_t max_nesting);
+
+extern void
+hoedown_document_set_parse_custom(
+    hoedown_document *doc,
+    size_t (*func)(hoedown_buffer *ob, hoedown_document *doc, uint8_t *data, size_t size));
+
+extern hoedown_renderer *hoedown_document_get_renderer(hoedown_document *doc);
+
+extern void *hoedown_document_get_data(hoedown_document *doc);
+
+extern void
+hoedown_document_set_special_char(hoedown_document *doc, uint8_t c, int flag);
+
+extern void
+hoedown_document_remove_special_char(hoedown_document *doc, uint8_t c);
 
 extern void
 hoedown_document_render(hoedown_document *doc, hoedown_buffer *ob, const uint8_t *document, size_t doc_size);

--- a/src/html.c
+++ b/src/html.c
@@ -489,10 +489,10 @@ rndr_footnotes(hoedown_buffer *ob, const hoedown_buffer *text, void *opaque)
 	HOEDOWN_BUFPUTSL(ob, "<div class=\"footnotes\">\n");
 	hoedown_buffer_puts(ob, USE_XHTML(state) ? "<hr/>\n" : "<hr>\n");
 	HOEDOWN_BUFPUTSL(ob, "<ol>\n");
-	
+
 	if (text)
 		hoedown_buffer_put(ob, text->data, text->size);
-	
+
 	HOEDOWN_BUFPUTSL(ob, "\n</ol>\n</div>\n");
 }
 
@@ -501,7 +501,7 @@ rndr_footnote_def(hoedown_buffer *ob, const hoedown_buffer *text, unsigned int n
 {
 	size_t i = 0;
 	int pfound = 0;
-	
+
 	/* insert anchor at the end of first paragraph block */
 	if (text) {
 		while ((i+3) < text->size) {
@@ -514,7 +514,7 @@ rndr_footnote_def(hoedown_buffer *ob, const hoedown_buffer *text, unsigned int n
 			break;
 		}
 	}
-	
+
 	hoedown_buffer_printf(ob, "\n<li id=\"fn%d\">\n", num);
 	if (pfound) {
 		hoedown_buffer_put(ob, text->data, i);
@@ -627,7 +627,9 @@ hoedown_html_toc_renderer_new(int nesting_level)
 		NULL,
 
 		NULL,
-		toc_finalize
+		toc_finalize,
+
+        NULL
 	};
 
 	hoedown_html_renderer_state *state;
@@ -650,7 +652,7 @@ hoedown_html_toc_renderer_new(int nesting_level)
 	}
 
 	memcpy(renderer, &cb_default, sizeof(hoedown_renderer));
-	
+
 	renderer->opaque = state;
 	return renderer;
 }
@@ -658,7 +660,7 @@ hoedown_html_toc_renderer_new(int nesting_level)
 hoedown_renderer *
 hoedown_html_renderer_new(unsigned int render_flags, int nesting_level)
 {
-	static const hoedown_renderer cb_default = {		
+	static const hoedown_renderer cb_default = {
 		NULL,
 
 		rndr_blockcode,
@@ -695,7 +697,9 @@ hoedown_html_renderer_new(unsigned int render_flags, int nesting_level)
 		rndr_normal_text,
 
 		NULL,
-		NULL
+		NULL,
+
+        NULL
 	};
 
 	hoedown_html_renderer_state *state;
@@ -722,7 +726,7 @@ hoedown_html_renderer_new(unsigned int render_flags, int nesting_level)
 
 	if (render_flags & HOEDOWN_HTML_SKIP_HTML || render_flags & HOEDOWN_HTML_ESCAPE)
 		renderer->blockhtml = NULL;
-	
+
 	renderer->opaque = state;
 	return renderer;
 }


### PR DESCRIPTION
Since there are so many Markdown variants with custom syntaxes, maybe it would be better to give the user the ability to add extra rules to the parser/renderer.

What I currently have in mind is:

1. Add a function pointer member in `hoedown_document` and a `void *` data pointer for custom data.
2. Add helper functions to expose the function pointer and data field, and for setting special characters (`active_char`).
3. Add a function pointer in `hoedown_renderer`.
4. Call the `parse_custom` function in `parse_block`.

The user can do whatever he/she wants in the custom parsing function, including calling the rendering function. The rendering function includes a `data` argument if additional configs are required. If state is needed, the user can put whatever needed in the `data` field of the `hoedown_document` struct, too.

The PR is not expected to be merged as-is, I’m only including it to show how the idea is implemented, so that I can hear what you guys think.