### PR TITLE
Add hoedown_document_render_inline

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -149,6 +149,9 @@ extern void
 hoedown_document_render(hoedown_document *doc, hoedown_buffer *ob, const uint8_t *document, size_t doc_size);
 
 extern void
+hoedown_document_render_inline(hoedown_document *doc, hoedown_buffer *ob, const uint8_t *document, size_t doc_size);
+
+extern void
 hoedown_document_free(hoedown_document *doc);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Wether it's for short posts, or full articles, Markdown is great. But sometimes, a full Markdown render is too much.

This pull request adds a companion to `hoedown_document_render`: it's `hoedown_document_render_inline`. As the name implies, the content is passed directly to `parse_inline`, so it gets parsed as if it was regular Markdown inside of a paragraph, for instance.

The preprocessing done on this new method is much simpler than that of a regular render:
- All spacing is converted to spaces, directly. This prevents `parse_inline` from interpreting a linebreak.
- No reference or footnote processing.
- No BOM is interpreted.
- No linefeed is added at the end.
#### Use cases

You could use this on a Markdown-based **commenting system** similar to StackOverflow's (they call this "mini-markdown"):

![StackOverflow comment box](https://cloud.githubusercontent.com/assets/1177304/3845855/016f8d2e-1e57-11e4-98f6-6c0bca9cc8aa.png)

Or on a "Todo app":

![Some tasks](https://cloud.githubusercontent.com/assets/1177304/3846095/6244432c-1e59-11e4-94e4-feacac2f4e7a.png)

Or on Github itself, for titles:

![Thread title](https://cloud.githubusercontent.com/assets/1177304/3846113/96bfb10e-1e59-11e4-9efb-16dee16aa017.png)

You'd use this whenever you have short strings of text, and you want to give them some basic formatting.
#### Examples

```
Input:     Some **inline** markdown here!
Output:    Some <strong>inline</strong> markdown here!
```

```
Input:     - This is *not* a list item.
Output:    - This is <em>not</em> a list item.
```

```
Input:     Autolinking. http://ddg.gg
Output:    Autolinking. <a href="http://ddg.gg">http://ddg.gg</a>
```

```
Input:     > This < would be interpreted as a `blockquote`.
Output:    &gt; This &lt; would be interpreted as a <code>blockquote</code>.
```

```
Input:     Because images in short comments are unacceptable, the image callback was set
           to `NULL` in this example. ![image](http://something)
Output:    Because images in short comments are unacceptable, the image callback was set
           to <code>NULL</code> in this example. !<a href="http://something">image</a>
```
