### PR TITLE
Include strings.h to silence  warnings for strncasecmp

### DIFF
--- a/src/autolink.c
+++ b/src/autolink.c
@@ -5,7 +5,9 @@
 #include <stdio.h>
 #include <ctype.h>
 
-#ifdef _MSC_VER
+#ifndef _MSC_VER
+#include <strings.h>
+#else
 #define strncasecmp	_strnicmp
 #endif
 

--- a/src/document.c
+++ b/src/document.c
@@ -7,7 +7,9 @@
 
 #include "stack.h"
 
-#ifdef _MSC_VER
+#ifndef _MSC_VER
+#include <strings.h>
+#else
 #define strncasecmp	_strnicmp
 #endif
 


### PR DESCRIPTION
When building hoedown, I noticed two implicit declaration warnings for ´strncasecmp´. This PR includes `strings.h` if not built with MSC.
