### PR TITLE
Remove HTML_SAFELINK and EXT_LAX_SPACING

### DIFF
--- a/bin/hoedown.c
+++ b/bin/hoedown.c
@@ -66,7 +66,6 @@ static struct extension_info extensions_info[] = {
 	{HOEDOWN_EXT_SUPERSCRIPT, "superscript", "Parse super^script."},
 	{HOEDOWN_EXT_MATH, "math", "Parse TeX $$math$$ syntax, Kramdown style."},
 
-	{HOEDOWN_EXT_LAX_SPACING, "lax-spacing", "Don't require a blank line between some blocks."},
 	{HOEDOWN_EXT_NO_INTRA_EMPHASIS, "disable-intra-emphasis", "Disable emphasis_between_words."},
 	{HOEDOWN_EXT_SPACE_HEADERS, "space-headers", "Require a space after '#' in headers."},
 	{HOEDOWN_EXT_MATH_EXPLICIT, "math-explicit", "Instead of guessing by context, parse $inline math$ and $$always block math$$ (requires --math)."},
@@ -77,7 +76,6 @@ static struct extension_info extensions_info[] = {
 static struct html_flag_info html_flags_info[] = {
 	{HOEDOWN_HTML_SKIP_HTML, "skip-html", "Strip all HTML tags."},
 	{HOEDOWN_HTML_ESCAPE, "escape", "Escape all HTML."},
-	{HOEDOWN_HTML_SAFELINK, "safelink", "Only allow links to safe protocols."},
 	{HOEDOWN_HTML_HARD_WRAP, "hard-wrap", "Render each linebreak as <br>."},
 	{HOEDOWN_HTML_USE_XHTML, "xhtml", "Render XHTML."},
 };

--- a/src/document.c
+++ b/src/document.c
@@ -1638,37 +1638,6 @@ parse_paragraph(hoedown_buffer *ob, hoedown_document *doc, uint8_t *data, size_t
 			break;
 		}
 
-		/*
-		 * Early termination of a paragraph with the same logic
-		 * as Markdown 1.0.0. If this logic is applied, the
-		 * Markdown 1.0.3 test suite won't pass cleanly
-		 *
-		 * :: If the first character in a new line is not a letter,
-		 * let's check to see if there's some kind of block starting
-		 * here
-		 */
-		if ((doc->ext_flags & HOEDOWN_EXT_LAX_SPACING) && !isalnum(data[i])) {
-			if (prefix_oli(data + i, size - i) ||
-				prefix_uli(data + i, size - i)) {
-				end = i;
-				break;
-			}
-
-			/* see if an html block starts here */
-			if (data[i] == '<' && doc->md.blockhtml &&
-				parse_htmlblock(ob, doc, data + i, size - i, 0)) {
-				end = i;
-				break;
-			}
-
-			/* see if a code fence starts here */
-			if ((doc->ext_flags & HOEDOWN_EXT_FENCED_CODE) != 0 &&
-				is_codefence(data + i, size - i, NULL, NULL)) {
-				end = i;
-				break;
-			}
-		}
-
 		i = end;
 	}
 

--- a/src/document.h
+++ b/src/document.h
@@ -31,7 +31,6 @@ typedef enum hoedown_extensions {
 	HOEDOWN_EXT_MATH = (1 << 9),
 
 	/* other flags */
-	HOEDOWN_EXT_LAX_SPACING = (1 << 10),
 	HOEDOWN_EXT_NO_INTRA_EMPHASIS = (1 << 11),
 	HOEDOWN_EXT_SPACE_HEADERS = (1 << 12),
 	HOEDOWN_EXT_MATH_EXPLICIT = (1 << 13),
@@ -55,7 +54,6 @@ typedef enum hoedown_extensions {
 	HOEDOWN_EXT_MATH )
 
 #define HOEDOWN_EXT_FLAGS (\
-	HOEDOWN_EXT_LAX_SPACING |\
 	HOEDOWN_EXT_NO_INTRA_EMPHASIS |\
 	HOEDOWN_EXT_SPACE_HEADERS |\
 	HOEDOWN_EXT_MATH_EXPLICIT )

--- a/src/html.c
+++ b/src/html.c
@@ -63,11 +63,6 @@ rndr_autolink(hoedown_buffer *ob, const hoedown_buffer *link, hoedown_autolink_t
 	if (!link || !link->size)
 		return 0;
 
-	if ((state->flags & HOEDOWN_HTML_SAFELINK) != 0 &&
-		!hoedown_autolink_is_safe(link->data, link->size) &&
-		type != HOEDOWN_AUTOLINK_EMAIL)
-		return 0;
-
 	HOEDOWN_BUFPUTSL(ob, "<a href=\"");
 	if (type == HOEDOWN_AUTOLINK_EMAIL)
 		HOEDOWN_BUFPUTSL(ob, "mailto:");
@@ -237,9 +232,6 @@ static int
 rndr_link(hoedown_buffer *ob, const hoedown_buffer *link, const hoedown_buffer *title, const hoedown_buffer *content, void *opaque)
 {
 	hoedown_html_renderer_state *state = opaque;
-
-	if (link != NULL && (state->flags & HOEDOWN_HTML_SAFELINK) != 0 && !hoedown_autolink_is_safe(link->data, link->size))
-		return 0;
 
 	HOEDOWN_BUFPUTSL(ob, "<a href=\"");
 

--- a/src/html.h
+++ b/src/html.h
@@ -18,9 +18,8 @@ extern "C" {
 typedef enum hoedown_html_flags {
 	HOEDOWN_HTML_SKIP_HTML = (1 << 0),
 	HOEDOWN_HTML_ESCAPE = (1 << 1),
-	HOEDOWN_HTML_SAFELINK = (1 << 2),
-	HOEDOWN_HTML_HARD_WRAP = (1 << 3),
-	HOEDOWN_HTML_USE_XHTML = (1 << 4)
+	HOEDOWN_HTML_HARD_WRAP = (1 << 2),
+	HOEDOWN_HTML_USE_XHTML = (1 << 3)
 } hoedown_html_flags;
 
 typedef enum hoedown_html_tag {


### PR DESCRIPTION
Pull request to remove the following flags (see #128):
- `HOEDOWN_EXT_LAX_SPACING`
- `HOEDOWN_HTML_SAFELINK`
