### PR TITLE
Make tab expansion UTF-8 aware.

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -2662,13 +2662,22 @@ is_ref(const uint8_t *data, size_t beg, size_t end, size_t *last, struct link_re
 
 static void expand_tabs(hoedown_buffer *ob, const uint8_t *line, size_t size)
 {
+	/* This code makes two assumptions:
+	 * - Input is valid UTF-8.  (Any byte with top two bits 10 is skipped,
+	 *   whether or not it is a valid UTF-8 continuation byte.)
+	 * - Input contains no combining characters.  (Combining characters
+	 *   should be skipped but are not.)
+	 */
 	size_t  i = 0, tab = 0;
 
 	while (i < size) {
 		size_t org = i;
 
 		while (i < size && line[i] != '\t') {
-			i++; tab++;
+			i++;
+			/* ignore UTF-8 continuation bytes */
+			if ((line[i] & 0xc0) != 0x80)
+				tab++;
 		}
 
 		if (i > org)


### PR DESCRIPTION
Tab expansion during preprocessing should align on UTF-8 characters, not bytes.  See [CommonMark spec, example 2](http://jgm.github.io/stmd/spec.html#example-2).  Before this patch, hoedown would fail the CommonMark test with the following:

```
✘ Example 2 (line 212)
=== markdown ===============
    a→a
    ὐ→a
=== expected ===============
<pre><code>a   a
ὐ   a
</code></pre>
=== got ====================
<pre><code>a   a
ὐ a
</code></pre>
```

Note that, unlike Unicode support for case-insensitive link names (#105), this does not require a special library.  We can simply skip over any bytes where `(c & 0xc0) == 0x80`.  (This assumes the input is valid UTF-8.)
