### PR TITLE
Make tests work on Windows

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -34,3 +34,8 @@ clean:
 
 .c.obj:
 	$(CC) $(CFLAGS) /c $< /Fo$@
+
+# Testing
+
+test: hoedown.exe
+	python test\runner.py

--- a/test/runner.py
+++ b/test/runner.py
@@ -49,19 +49,18 @@ def _test_func(test_case):
         HOEDOWN + flags + [os.path.join(TEST_ROOT, test_case['input'])],
         stdout=subprocess.PIPE,
     )
-    hoedown_proc.wait()
+    stdoutdata = hoedown_proc.communicate()[0]
+
     got_tidy_proc = subprocess.Popen(
-        TIDY, stdin=hoedown_proc.stdout, stdout=subprocess.PIPE,
+        TIDY, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
     )
-    got_tidy_proc.wait()
-    got = got_tidy_proc.stdout.read().strip()
+    got = got_tidy_proc.communicate(input=stdoutdata)[0].strip()
 
     expected_tidy_proc = subprocess.Popen(
         TIDY + [os.path.join(TEST_ROOT, test_case['output'])],
         stdout=subprocess.PIPE,
     )
-    expected_tidy_proc.wait()
-    expected = expected_tidy_proc.stdout.read().strip()
+    expected = expected_tidy_proc.communicate()[0].strip()
 
     # Cleanup.
     hoedown_proc.stdout.close()


### PR DESCRIPTION
It occurred to me when testing VS builds that the VS Makefile does not have a test task, so I added that. The test runner stuck on Windows, probably due to `wait()` usages causing dead locks on large inputs, so I changed those to use `communicate()` instead, which is promised (by Python’s documentation) to work.

Obviously this needs both `python` (any modern version) and `tidy` in your `PATH` to work. I use [Letzte Bearbeitung’s HTML Tidy for Windows executable](http://www.paehl.com/open_source/?HTML_Tidy_for_Windows).
