### PR TITLE
Add the podspec for CocoaPods

### DIFF
--- a/hoedown.podspec
+++ b/hoedown.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |s|
+  s.name = 'hoedown'
+  s.version = '3.0.1'
+  s.summary = 'Standards compliant, fast, secure markdown processing library in C. A fork of sundown.'
+  s.homepage = 'https://github.com/hoedown/hoedown'
+  s.license = 'MIT'
+  s.author = { 'Natacha Porte' => '',
+               'Vincent Marti' => '',
+               'Devin Torres and the hoedown authors' => 'devin@devintorr.es',
+               'Clemens Gruber (podspec)' => 'clemensgru@gmail.com' }
+  s.source = { :git => 'https://github.com/hoedown/hoedown.git', :tag => '3.0.1' }
+  s.requires_arc = false
+
+  s.default_subspec = 'standard'
+
+  s.subspec 'standard' do |ss|
+    ss.source_files = 'src/*.{c,h}'
+  end
+end


### PR DESCRIPTION
Hi,

this is the current podspec file for CocoaPods to use hoedown 3.0.1. I could maintain it in a separate repository but as it is just a small file and most people wanting to change it will search here in the main hoedown repository, I think it would be a good idea to add it. (Most projects have it in the main repo)
I am at the moment registered with CocoaPods Trunk, but if you want I'll add you as owners of the hoedown pod, so you can push new versions of the pod, if I am unable to maintain it in the future.

Signed-off-by: Clemens Gruber <clemensgru@gmail.com>