### PR TITLE
allow the HOEDOWN_EXT_UNDERLINE to work

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -2751,7 +2751,7 @@ hoedown_document_new(
 
 	memset(doc->active_char, 0x0, 256);
 
-	if (doc->md.emphasis || doc->md.double_emphasis || doc->md.triple_emphasis) {
+	if (doc->md.emphasis || doc->md.double_emphasis || doc->md.triple_emphasis || doc->md.underline) {
 		doc->active_char['*'] = MD_CHAR_EMPHASIS;
 		doc->active_char['_'] = MD_CHAR_EMPHASIS;
 		if (extensions & HOEDOWN_EXT_STRIKETHROUGH)

--- a/test/Tests/Underline.html
+++ b/test/Tests/Underline.html
@@ -1,0 +1,1 @@
+<p>This <u>underline</u> will work.</p>

--- a/test/Tests/Underline.text
+++ b/test/Tests/Underline.text
@@ -1,0 +1,1 @@
+This _underline_ will work.

--- a/test/config.json
+++ b/test/config.json
@@ -101,6 +101,11 @@
             "input": "Tests/Math.text",
             "output": "Tests/Math.html",
             "flags": ["--math"]
+        },
+        {
+            "input": "Tests/Underline.text",
+            "output": "Tests/Underline.html",
+            "flags": ["--underline"]
         }
     ]
 }


### PR DESCRIPTION
When the `HOEDOWN_EXT_UNDERLINE` extension was enabled, underlined spans
would actually be passed verbatim to the output buffer. This was because
the active_char was _only_ set when the emphasis, double_emphasis, or
triple_emphasis handlers were registered. As a result, no active char
was found in the input buffer, so everything was passed through
verbatim.

This patch fixes this by also registering the `active_char` if the
underline handler is registered. I also added a simple regression test.

I personally don't use this extension, but I encountered this bug over
the course of writing bindings for Rust.