### PR TITLE
Implement backslash escape of EOL as a hard line break.

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -917,6 +917,18 @@ char_escape(hoedown_buffer *ob, hoedown_document *doc, uint8_t *data, size_t off
 			if (w) return w;
 		}
 
+		if (data[1] == '\n') {
+			if (doc->md.linebreak)
+				doc->md.linebreak(ob, &doc->data);
+			return 2;
+		}
+
+		if (size > 2 && data[1] == '\r' && data[2] == '\n') {
+			if (doc->md.linebreak)
+				doc->md.linebreak(ob, &doc->data);
+			return 3;
+		}
+
 		if (strchr(escape_chars, data[1]) == NULL)
 			return 0;
 

--- a/test/Tests/Escape character.html
+++ b/test/Tests/Escape character.html
@@ -49,3 +49,5 @@
 <p><a href="http://example.com">Foo\]</a></p>
 
 <p><a href="http://example.com">Foo\\</a></p>
+
+<p>Line break<br/>Broken line</p>

--- a/test/Tests/Escape character.text
+++ b/test/Tests/Escape character.text
@@ -49,3 +49,6 @@ Super\^script
 [Foo\\\]](http://example.com)
 
 [Foo\\\\](http://example.com)
+
+Line break\
+Broken line


### PR DESCRIPTION
See Commonmark 0.18, example 232. This patch implements it for LF and CRLF
style line endings.