### PR TITLE
Source mapping

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -3023,7 +3023,7 @@ static size_t parse_list(hoedown_document *doc, void *target, const uint8_t *dat
     if (current_mode == NORMAL_PARSING) {
       void *item_content = doc->rndr.object_get(0, &doc->data);
       parse_block(doc, item_content, work->data + offset, new_offset - offset, new_offset - offset, 0);
-      set_buffer_data(&doc->data.src[0], data, source, new_source);
+      set_buffer_data(&doc->data.src[0], data + start, source, new_source);
       set_buffer_data(&doc->data.src[1], work->data, offset, new_offset);
       doc->rndr.list_item(content, item_content, is_ordered, !is_loose, &doc->data);
       doc->rndr.object_pop(item_content, 0, &doc->data);

--- a/src/document.h
+++ b/src/document.h
@@ -260,6 +260,13 @@ void *hoedown_document_render(
   int is_inline, void *request
 );
 
+/* hoedown_document_locate: locate original position(s) of a chunk of Markdown */
+int hoedown_document_locate(
+  hoedown_internal *doc,
+  hoedown_list *ranges,
+  const uint8_t *data, size_t size
+);
+
 /* hoedown_document_free: deallocate a document processor */
 void hoedown_document_free(hoedown_document *doc);
 

--- a/src/document.h
+++ b/src/document.h
@@ -4,7 +4,7 @@
 #define HOEDOWN_DOCUMENT_H
 
 #include "buffer.h"
-#include "autolink.h"
+#include "list.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -181,6 +181,12 @@ typedef struct hoedown_renderer_data {
   void *request;
   hoedown_internal *doc;
 } hoedown_renderer_data;
+
+typedef struct hoedown_range {
+  size_t source;
+  size_t size;
+  size_t skip;
+} hoedown_range;
 
 typedef struct hoedown_renderer {
   void *opaque;


### PR DESCRIPTION
This is a proposal for cheap (but still powerful) source mapping in Hoedown. I still want to:
- Introduce a simple optimization to speed up lookup.
- Maybe add a `HOEDOWN_FT_SOURCE_MAPPING` flag if source mapping adds significant overhead.
## The API

``` c
struct hoedown_range {
  size_t source;
  size_t size;
  size_t skip;
};

int hoedown_document_locate(hoedown_internal *doc, hoedown_list *ranges, const uint8_t *data, size_t size);
```

The API is simple, but takes a bit to understand. It _must_ be used inside a renderer callback like this:

``` c
void render_atx_header(void *target, void *content, size_t width, const hoedown_renderer *data) {
  // Retrieve the Markdown belonging to this header
  hoedown_buffer *source = data->src;
  // Create a list to receive resulting ranges
  hoedown_list ranges;
  hoedown_list_init(&ranges, sizeof(hoedown_render), 1);
  // Locate `source` contents in the original input
  int found = hoedown_document_locate(data->doc, &ranges, source->data, source->size);
```

At that point, if `found` is nonzero, `ranges` will contain zero or more `hoedown_range` objects, which can be accessed with `HOEDOWN_LIGET`:

``` c
  // Print each range
  for (size_t i = 0; i < ranges.size; i++) {
    hoedown_range *range = HOEDOWN_LIGET(&ranges, i, hoedown_range);
    printf("Range: source %u, size %u, skip %u.\n", range->source, range->size, range->skip);
  }
  // Free the list
  hoedown_list_uninit(&ranges);
}
```
## Model

Each range object has three attributes: `source`, `size` and `skip`. `source` is the position of the first mapped character in the original input. `size` is the number of mapped characters. `skip` is the position of the first mapped character in the located chunk, relative to the last range end.

An example illustrates this well. Suppose you have the following Markdown (there's a tab just before "bar", i.e. `> **foo\n> \tbar**\n`):

```
> **foo
>   bar**
```

If you obtained the source of the emphasis span (`**foo\n  bar**`) and located it using the above API, you'd obtain two ranges:

```
Range: source 2, size 6, skip 0.
Range: source 11, size 5, skip 2.
```

The first range tells us the first 6 characters in the chunk (`**foo\n`) are found in position 2 of the input. This is true, as we can see.

The second range tells us the next 2 characters (the spaces) cannot be traced directly to the input (they come from the tab). After that, the next 5 characters (`bar**`) are found at position 11 of the input.
