### PR TITLE
Fix rendering in table with empty cells

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -2225,7 +2225,15 @@ parse_table_row(
 		cell_start = i;
 
 		len = find_emph_char(data + i, size - i, '|');
-		i += len ? len : size - i;
+
+		/* Two possibilities for len == 0:
+		   1) No more pipe char found in the current line.
+		   2) The next pipe is right after the current one, i.e. empty cell.
+		   For case 1, we skip to the end of line; for case 2 we just continue.
+		*/
+		if (len == 0 && data[i] != '|')
+			len = size - i;
+		i += len;
 
 		cell_end = i - 1;
 

--- a/test/Tests/Table.html
+++ b/test/Tests/Table.html
@@ -1,0 +1,66 @@
+<h1>Standard table</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>headline1</th>
+      <th>headline2</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>123</td>
+      <td></td>
+    </tr>
+  </tbody>
+</table>
+
+
+<h1>Cell alignment</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th style="text-align: left">headline1</th>
+      <th style="text-align: center">headline2</th>
+      <th style="text-align: right">headline3</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style="text-align: left">123</td>
+      <td style="text-align: center"></td>
+      <td style="text-align: right"></td>
+    </tr>
+  </tbody>
+</table>
+
+
+<h1>Malformed table: missing cell at row in body</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>headline1</th>
+      <th>headline2</th>
+      <th>headline3</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>12</td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>34</td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>56</td>
+      <td></td>
+      <td></td>
+    </tr>
+  </tbody>
+</table>

--- a/test/Tests/Table.text
+++ b/test/Tests/Table.text
@@ -1,0 +1,21 @@
+# Standard table
+
+|headline1|headline2|
+|---------|---------|
+|123      |         |
+
+
+# Cell alignment
+
+|headline1|headline2|headline3|
+|:-------|:------:|------:|
+|123|||
+
+
+# Malformed table: missing cell at row in body
+
+|headline1|headline2|headline3|
+|-------|-------|-------|
+|12
+|34||
+|56|

--- a/test/config.json
+++ b/test/config.json
@@ -106,6 +106,11 @@
             "input": "Tests/Underline.text",
             "output": "Tests/Underline.html",
             "flags": ["--underline"]
+        },
+        {
+            "input": "Tests/Table.text",
+            "output": "Tests/Table.html",
+            "flags": ["--tables"]
         }
     ]
 }


### PR DESCRIPTION
This is for the 3.0 branch.

`find_emph_char` returns 0 if the char specified is not found in the current line, but this is also what happens when there's an empty cell. This patch adds logic to work around this problem.

Tests added for general table syntax validation. The last example in `Table.text` addresses the problem mentioned.

See uranusjr/macdown#321.