### PR TITLE
Block parsing function

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -164,6 +164,8 @@ void hoedown_document_render_inline(hoedown_document *doc, hoedown_buffer *ob, c
 /* hoedown_document_free: deallocate a document processor instance */
 void hoedown_document_free(hoedown_document *doc);
 
+/* parse_first_block • parsing of one block, the length that has been parsed is returned as o_parsed */
+int parse_first_block(hoedown_buffer *ob, hoedown_document *doc, uint8_t *data, size_t size, int *o_parsed);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Hi,
I've forked the parse_block to a seperate function that parses the first block only and returns the format and the length of the content that had been parsed. Can be used in a loop as a renderer. The advantage is that projects that use hoedown library for parsing can parse the document block by block instead of doing it as a whole.