### PR TITLE
Adding support for `-> centered content <-` like markdown language

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -1199,8 +1199,10 @@ char_link(hoedown_buffer *ob, hoedown_document *doc, uint8_t *data, size_t offse
 			link_e--;
 
 		/* remove optional angle brackets around the link */
-		if (data[link_b] == '<') link_b++;
-		if (data[link_e - 1] == '>') link_e--;
+		if (data[link_b] == '<' && data[link_e - 1] == '>') {
+			link_b++;
+			link_e--;
+		}
 
 		/* building escaped link and title */
 		if (link_e > link_b) {

--- a/src/document.h
+++ b/src/document.h
@@ -101,7 +101,7 @@ struct hoedown_renderer {
 	/* block level callbacks - NULL skips the block */
 	void (*blockcode)(hoedown_buffer *ob, const hoedown_buffer *text, const hoedown_buffer *lang, const hoedown_renderer_data *data);
 	void (*blockquote)(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_renderer_data *data);
-        void (*centerofline)(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_renderer_data *data);
+	void (*centerofline)(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_renderer_data *data);
 	void (*header)(hoedown_buffer *ob, const hoedown_buffer *content, int level, const hoedown_renderer_data *data);
 	void (*hrule)(hoedown_buffer *ob, const hoedown_renderer_data *data);
 	void (*list)(hoedown_buffer *ob, const hoedown_buffer *content, hoedown_list_flags flags, const hoedown_renderer_data *data);

--- a/src/document.h
+++ b/src/document.h
@@ -101,6 +101,7 @@ struct hoedown_renderer {
 	/* block level callbacks - NULL skips the block */
 	void (*blockcode)(hoedown_buffer *ob, const hoedown_buffer *text, const hoedown_buffer *lang, const hoedown_renderer_data *data);
 	void (*blockquote)(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_renderer_data *data);
+    void (*centerofline)(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_renderer_data *data);
 	void (*header)(hoedown_buffer *ob, const hoedown_buffer *content, int level, const hoedown_renderer_data *data);
 	void (*hrule)(hoedown_buffer *ob, const hoedown_renderer_data *data);
 	void (*list)(hoedown_buffer *ob, const hoedown_buffer *content, hoedown_list_flags flags, const hoedown_renderer_data *data);

--- a/src/document.h
+++ b/src/document.h
@@ -101,7 +101,7 @@ struct hoedown_renderer {
 	/* block level callbacks - NULL skips the block */
 	void (*blockcode)(hoedown_buffer *ob, const hoedown_buffer *text, const hoedown_buffer *lang, const hoedown_renderer_data *data);
 	void (*blockquote)(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_renderer_data *data);
-    void (*centerofline)(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_renderer_data *data);
+        void (*centerofline)(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_renderer_data *data);
 	void (*header)(hoedown_buffer *ob, const hoedown_buffer *content, int level, const hoedown_renderer_data *data);
 	void (*hrule)(hoedown_buffer *ob, const hoedown_renderer_data *data);
 	void (*list)(hoedown_buffer *ob, const hoedown_buffer *content, hoedown_list_flags flags, const hoedown_renderer_data *data);

--- a/src/html.c
+++ b/src/html.c
@@ -120,6 +120,14 @@ rndr_blockquote(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown
 	HOEDOWN_BUFPUTSL(ob, "</blockquote>\n");
 }
 
+static void
+rndr_centerofline(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_renderer_data *data)
+{
+    HOEDOWN_BUFPUTSL(ob, "<center>");
+    hoedown_buffer_put(ob, content->data, content->size);
+    HOEDOWN_BUFPUTSL(ob, "</center>\n");
+}
+
 static int
 rndr_codespan(hoedown_buffer *ob, const hoedown_buffer *text, const hoedown_renderer_data *data)
 {
@@ -624,6 +632,7 @@ hoedown_html_toc_renderer_new(int nesting_level)
 
 		NULL,
 		NULL,
+        NULL,
 		toc_header,
 		NULL,
 		NULL,
@@ -687,6 +696,7 @@ hoedown_html_renderer_new(hoedown_html_flags render_flags, int nesting_level)
 
 		rndr_blockcode,
 		rndr_blockquote,
+        rndr_centerofline,
 		rndr_header,
 		rndr_hrule,
 		rndr_list,

--- a/src/version.h
+++ b/src/version.h
@@ -12,10 +12,10 @@ extern "C" {
  * CONSTANTS *
  *************/
 
-#define HOEDOWN_VERSION "3.0.5"
+#define HOEDOWN_VERSION "3.0.3"
 #define HOEDOWN_VERSION_MAJOR 3
 #define HOEDOWN_VERSION_MINOR 0
-#define HOEDOWN_VERSION_REVISION 5
+#define HOEDOWN_VERSION_REVISION 3
 
 
 /*************

--- a/src/version.h
+++ b/src/version.h
@@ -12,10 +12,10 @@ extern "C" {
  * CONSTANTS *
  *************/
 
-#define HOEDOWN_VERSION "3.0.4"
+#define HOEDOWN_VERSION "3.0.5"
 #define HOEDOWN_VERSION_MAJOR 3
 #define HOEDOWN_VERSION_MINOR 0
-#define HOEDOWN_VERSION_REVISION 4
+#define HOEDOWN_VERSION_REVISION 5
 
 
 /*************


### PR DESCRIPTION
* `->` must be at the start of each line.
* trailing spaces after `<-` are ignored.
* embedded md are supported like `-> centered _underline_ here <-` or `->#centered level 1 heading here<-`.