### PR TITLE
Use -install_name on Darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,11 @@ ifneq ($(OS),Windows_NT)
 	HOEDOWN_CFLAGS += -fPIC
 endif
 
+SONAME = -soname
+ifeq ($(shell uname -s),Darwin)
+	SONAME = -install_name
+endif
+
 HOEDOWN_SRC=\
 	src/autolink.o \
 	src/buffer.o \
@@ -30,7 +35,7 @@ libhoedown.so: libhoedown.so.3
 	ln -f -s $^ $@
 
 libhoedown.so.3: $(HOEDOWN_SRC)
-	$(CC) -Wl,-soname,$(@F) -shared $^ $(LDFLAGS) -o $@
+	$(CC) -Wl,$(SONAME),$(@F) -shared $^ $(LDFLAGS) -o $@
 
 libhoedown.a: $(HOEDOWN_SRC)
 	$(AR) rcs libhoedown.a $^


### PR DESCRIPTION
This fixes compilation on Darwin targets.

Fixes #167.

Simple solution until the `develop` branch lands.

@jmendeth 
