### PR TITLE
Fix char_escape and char_entity so that when they fail, they attempt to put their output through normal_text before copying directly to the output

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -942,7 +942,12 @@ char_escape(hoedown_buffer *ob, hoedown_document *doc, uint8_t *data, size_t off
 		}
 		else hoedown_buffer_putc(ob, data[1]);
 	} else if (size == 1) {
-		hoedown_buffer_putc(ob, data[0]);
+		if (doc->md.normal_text) {
+			work.data = data;
+			work.size = 1;
+			doc->md.normal_text(ob, &work, &doc->data);
+		}
+		else hoedown_buffer_putc(ob, data[0]);
 	}
 
 	return 2;
@@ -971,6 +976,11 @@ char_entity(hoedown_buffer *ob, hoedown_document *doc, uint8_t *data, size_t off
 		work.data = data;
 		work.size = end;
 		doc->md.entity(ob, &work, &doc->data);
+	}
+	else if (doc->md.normal_text) {
+		work.data = data;
+		work.size = end;
+		doc->md.normal_text(ob, &work, &doc->data);
 	}
 	else hoedown_buffer_put(ob, data, end);
 

--- a/src/html.c
+++ b/src/html.c
@@ -489,6 +489,13 @@ rndr_superscript(hoedown_buffer *ob, const hoedown_buffer *content, const hoedow
 }
 
 static void
+rndr_entity(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_renderer_data *data)
+{
+	if (content)
+		hoedown_buffer_put(ob, content->data, content->size);
+}
+
+static void
 rndr_normal_text(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_renderer_data *data)
 {
 	if (content)
@@ -655,7 +662,7 @@ hoedown_html_toc_renderer_new(int nesting_level)
 		NULL,
 		NULL,
 
-		NULL,
+		rndr_entity,
 		rndr_normal_text,
 
 		NULL,
@@ -718,7 +725,7 @@ hoedown_html_renderer_new(hoedown_html_flags render_flags, int nesting_level)
 		rndr_math,
 		rndr_raw_html,
 
-		NULL,
+		rndr_entity,
 		rndr_normal_text,
 
 		NULL,


### PR DESCRIPTION
Change char_escape and char_entity so that when they fail, they attempt to put their output through normal_text before copying directly to the output. Before this, you could have weird situations where a rogue backslash or entity avoids going through normal_text. The common pattern through the rest of the parser is that normal_text is given first dibs before copying directly to the output. Since html.c relied on this behavior, had to explicitly define an entity callback for it.