### PR TITLE
Change char_escape to pass non-escaping backslashes through normal_text

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -942,7 +942,12 @@ char_escape(hoedown_buffer *ob, hoedown_document *doc, uint8_t *data, size_t off
 		}
 		else hoedown_buffer_putc(ob, data[1]);
 	} else if (size == 1) {
-		hoedown_buffer_putc(ob, data[0]);
+		if (doc->md.normal_text) {
+			work.data = data;
+			work.size = 1;
+			doc->md.normal_text(ob, &work, &doc->data);
+		}
+		else hoedown_buffer_putc(ob, data[0]);
 	}
 
 	return 2;


### PR DESCRIPTION
Change char_entity so that it is only used if an entity callback is defined. The previous behavior caused literal copies of entities to the output buffer if no callback was defined, skipping normal_text. Fixed the HTML renderer to account for this, by defining a simple entity callback. Entities should only be parsed like this if you want them to be (i.e. define a callback).

Change char_escape to pass its backslash through normal_text if it isn't escaping anything.