### PR TITLE
Make image parsing a little more sane, by having an explicit char_image function (that delegates most work to char_link).

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -77,6 +77,7 @@ static size_t char_autolink_url(hoedown_buffer *ob, hoedown_document *doc, uint8
 static size_t char_autolink_email(hoedown_buffer *ob, hoedown_document *doc, uint8_t *data, size_t offset, size_t size);
 static size_t char_autolink_www(hoedown_buffer *ob, hoedown_document *doc, uint8_t *data, size_t offset, size_t size);
 static size_t char_link(hoedown_buffer *ob, hoedown_document *doc, uint8_t *data, size_t offset, size_t size);
+static size_t char_image(hoedown_buffer *ob, hoedown_document *doc, uint8_t *data, size_t offset, size_t size);
 static size_t char_superscript(hoedown_buffer *ob, hoedown_document *doc, uint8_t *data, size_t offset, size_t size);
 static size_t char_math(hoedown_buffer *ob, hoedown_document *doc, uint8_t *data, size_t offset, size_t size);
 
@@ -86,6 +87,7 @@ enum markdown_char_t {
 	MD_CHAR_CODESPAN,
 	MD_CHAR_LINEBREAK,
 	MD_CHAR_LINK,
+	MD_CHAR_IMAGE,
 	MD_CHAR_LANGLE,
 	MD_CHAR_ESCAPE,
 	MD_CHAR_ENTITY,
@@ -103,6 +105,7 @@ static char_trigger markdown_char_ptrs[] = {
 	&char_codespan,
 	&char_linebreak,
 	&char_link,
+	&char_image,
 	&char_langle_tag,
 	&char_escape,
 	&char_entity,
@@ -1090,6 +1093,17 @@ char_autolink_url(hoedown_buffer *ob, hoedown_document *doc, uint8_t *data, size
 	return link_len;
 }
 
+static size_t
+char_image(hoedown_buffer *ob, hoedown_document *doc, uint8_t *data, size_t offset, size_t size) {
+	size_t ret;
+
+	if (size < 2 || data[1] != '[') return 0;
+
+	ret = char_link(ob, doc, data + 1, offset + 1, size - 1);
+	if (!ret) return 0;
+	return ret + 1;
+}
+
 /* char_link • '[': parsing a link, a footnote or an image */
 static size_t
 char_link(hoedown_buffer *ob, hoedown_document *doc, uint8_t *data, size_t offset, size_t size)
@@ -1302,9 +1316,6 @@ char_link(hoedown_buffer *ob, hoedown_document *doc, uint8_t *data, size_t offse
 
 	/* calling the relevant rendering function */
 	if (is_img) {
-		if (ob->size && ob->data[ob->size - 1] == '!')
-			ob->size -= 1;
-
 		ret = doc->md.image(ob, u_link, title, content, &doc->data);
 	} else {
 		ret = doc->md.link(ob, content, u_link, title, &doc->data);
@@ -2807,8 +2818,10 @@ hoedown_document_new(
 	if (doc->md.linebreak)
 		doc->active_char['\n'] = MD_CHAR_LINEBREAK;
 
-	if (doc->md.image || doc->md.link || doc->md.footnotes || doc->md.footnote_ref)
+	if (doc->md.image || doc->md.link || doc->md.footnotes || doc->md.footnote_ref) {
 		doc->active_char['['] = MD_CHAR_LINK;
+		doc->active_char['!'] = MD_CHAR_IMAGE;
+	}
 
 	doc->active_char['<'] = MD_CHAR_LANGLE;
 	doc->active_char['\\'] = MD_CHAR_ESCAPE;

--- a/test/Tests/Images.html
+++ b/test/Tests/Images.html
@@ -1,0 +1,9 @@
+<p>This is an <img src="/url" alt="image">.</p>
+
+<p>This is a tricky !<img src="/url" alt="image">.</p>
+
+<p>This is another tricky case: !<a href="/url">not image</a>.</p>
+
+<p>This is a reference <img src="/url2" alt="image">.</p>
+
+<p>Terminating !</p>

--- a/test/Tests/Images.text
+++ b/test/Tests/Images.text
@@ -1,0 +1,11 @@
+This is an ![image](/url).
+
+This is a tricky !![image](/url).
+
+This is another tricky case: \![not image](/url).
+
+This is a reference ![image][ref].
+
+[ref]: /url2
+
+Terminating !

--- a/test/config.json
+++ b/test/config.json
@@ -115,6 +115,11 @@
             "input": "Tests/Table.text",
             "output": "Tests/Table.html",
             "flags": ["--tables"]
+        },
+        {
+            "input": "Tests/Images.text",
+            "output": "Tests/Images.html",
+            "flags": []
         }
     ]
 }


### PR DESCRIPTION
Make image parsing a little more sane, by having an explicit char_image function (that delegates most work to char_link).

The current situation is incredibly hacky, because char_link has to reach into the output buffer to remove the last exclamation mark. For a non-standard renderer that does not just echo normal text to the output, this doesn't work well.

Quite surprisingly, there were no tests yet for image rendering (!) so I added some.
