### PR TITLE
Initialize new memory to 0 after buffer_realloc

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -113,6 +113,7 @@ hoedown_buffer_grow(hoedown_buffer *buf, size_t neosz)
 		neoasz += buf->unit;
 
 	buf->data = buf->data_realloc(buf->data, neoasz);
+	memset(&buf->data[buf->asize], 0, neoasz - buf->asize);
 	buf->asize = neoasz;
 }
 


### PR DESCRIPTION
The function “hoedown_buffer_cstr” would report uninitialized values in
valgrind when checking “buf->data[buf->size]”. Using —track-origins
revealed that the uninitialized value originated from the
hoedown_buffer_realloc function, which is resolved by introducing the
memset.
