### PR TITLE
Fix misleading intentation warning

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -1191,7 +1191,8 @@ char_link(hoedown_buffer *ob, hoedown_document *doc, uint8_t *data, size_t offse
 			}
 			else if (data[i] == ')') {
 				if (nb_p == 0) break;
-				else nb_p--; i++;
+				else nb_p--;
+				i++;
 			} else if (i >= 1 && _isspace(data[i-1]) && (data[i] == '\'' || data[i] == '"')) break;
 			else i++;
 		}


### PR DESCRIPTION
This patch fixes this warning.

```
src/document.c: In function ‘char_link’:
src/document.c:1194:5: warning: this ‘else’ clause does not guard... [-Wmisleading-indentation]
     else nb_p--; i++;
     ^~~~
src/document.c:1194:18: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the ‘else’
     else nb_p--; i++;
                  ^
```
