### PR TITLE
Support gperf 3.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ smartypants: bin/smartypants.o $(HOEDOWN_SRC)
 # Perfect hashing
 
 src/html_blocks.c: html_block_names.gperf
-	gperf -L ANSI-C -N hoedown_find_block_tag -c -C -E -S 1 --ignore-case -m100 $^ > $@
+	gperf -I -L ANSI-C -N hoedown_find_block_tag -c -C -E -S 1 --ignore-case -m100 $^ > $@
 
 # Testing
 


### PR DESCRIPTION
gperf 3.1 will output `register size_t n` instead of `register unsigned int n` like [here](https://github.com/hoedown/hoedown/blob/2508c4b/src/html_blocks.c#L62). This requires `stddef.h`; giving `-I` to the `gperf` invocation will include `string.h` which includes `stddef.h`.