### PR TITLE
Fixes compiler warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS = -g -O3 -ansi -pedantic -Wall -Wextra -Wno-unused-parameter
+CFLAGS = -g -O3 -std=c99 -pedantic -Wall -Wextra -Wno-unused-parameter
 PREFIX = /usr/local
 BINDIR = $(PREFIX)/bin
 LIBDIR = $(PREFIX)/lib

--- a/src/document.c
+++ b/src/document.c
@@ -1191,7 +1191,7 @@ char_link(hoedown_buffer *ob, hoedown_document *doc, uint8_t *data, size_t offse
 			}
 			else if (data[i] == ')') {
 				if (nb_p == 0) break;
-				else nb_p--; i++;
+				else { nb_p--; i++; }
 			} else if (i >= 1 && _isspace(data[i-1]) && (data[i] == '\'' || data[i] == '"')) break;
 			else i++;
 		}


### PR DESCRIPTION
This fixes a few compiler warnings:

```
$ make
...
src/buffer.c: In function ‘hoedown_buffer_printf’:
src/buffer.c:249:6: warning: implicit declaration of function ‘vsnprintf’; did you mean ‘vsprintf’? [-Wimplicit-function-declaration]
  n = vsnprintf((char *)buf->data + buf->size, buf->asize - buf->size, fmt, ap);
      ^~~~~~~~~
      vsprintf
...
src/document.c: In function ‘char_link’:
src/document.c:1194:5: warning: this ‘else’ clause does not guard... [-Wmisleading-indentation]
     else nb_p--; i++;
     ^~~~
src/document.c:1194:18: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘else’
     else nb_p--; i++;
                  ^
...
src/html_smartypants.c: In function ‘smartypants_quotes’:
src/html_smartypants.c:102:2: warning: implicit declaration of function ‘snprintf’; did you mean ‘sprintf’? [-Wimplicit-function-declaration]
  snprintf(ent, sizeof(ent), "&%c%cquo;", (*is_open) ? 'r' : 'l', quote);
  ^~~~~~~~
  sprintf
```