### PR TITLE
Detect fenced code block starting in first line of list item

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -1863,6 +1863,13 @@ parse_listitem(hoedown_buffer *ob, hoedown_document *doc, uint8_t *data, size_t 
 	while (end < size && data[end - 1] != '\n')
 		end++;
 
+	if (doc->ext_flags & HOEDOWN_EXT_FENCED_CODE) {
+		if (is_codefence(data + beg, end - beg, NULL, NULL)) {
+			in_fence = 1;
+			fence_pre = beg;
+		}
+	}
+
 	/* getting working buffers */
 	work = newbuf(doc, BUFFER_SPAN);
 	inter = newbuf(doc, BUFFER_SPAN);

--- a/test/Tests/extras/List_Item_Fenced_Code_First_Line.html
+++ b/test/Tests/extras/List_Item_Fenced_Code_First_Line.html
@@ -1,0 +1,14 @@
+<p><a href="https://github.com/hoedown/hoedown/issues/236">hoedown/hoedown#236</a> =
+<a href="https://github.com/kjdev/hoextdown/issues/57">kjdev/hoextdown#57</a></p>
+
+<ol>
+<li><p>First item.</p></li>
+<li><pre><code>Some code.
+More code.
+</code></pre>
+
+<p>There is code here.</p></li>
+<li><p>Third item.</p></li>
+</ol>
+
+<p>End of this list.</p>

--- a/test/Tests/extras/List_Item_Fenced_Code_First_Line.text
+++ b/test/Tests/extras/List_Item_Fenced_Code_First_Line.text
@@ -1,0 +1,15 @@
+[hoedown/hoedown#236](https://github.com/hoedown/hoedown/issues/236) =
+[kjdev/hoextdown#57](https://github.com/kjdev/hoextdown/issues/57)
+
+1. First item.
+
+1. ```
+   Some code.
+   More code.
+   ```
+
+   There is code here.
+
+1. Third item.
+
+End of this list.

--- a/test/config.json
+++ b/test/config.json
@@ -117,6 +117,11 @@
             "flags": ["--tables"]
         },
         {
+            "input": "Tests/extras/List_Item_Fenced_Code_First_Line.text",
+            "output": "Tests/extras/List_Item_Fenced_Code_First_Line.html",
+            "flags": ["--fenced-code"]
+        },
+        {
             "input": "Tests/Images.text",
             "output": "Tests/Images.html",
             "flags": []


### PR DESCRIPTION
Prior to this change, the in_fenced flag was not set correctly for the first line, and therefore inverted for every following line if the first line did start with a code block. Since the start of a subsequent list item is explicitly not detected while in fenced code, this essentially disabled the `has_next_oli` detection, leading to `HOEDOWN_LI_END` terminating not only the list item but the list as a whole.

Fixes https://github.com/hoedown/hoedown/issues/236.